### PR TITLE
Handle the 'no roles defined' case.

### DIFF
--- a/sensu/templates/client.json
+++ b/sensu/templates/client.json
@@ -1,4 +1,4 @@
-{% set roles=grains['roles'] %}
+{% set roles = grains['roles'] or [] %}
 {
   "client": {
     "name": "{{grains['fqdn']}}",


### PR DESCRIPTION
This prevents a failure when a server has no defined roles grain.

Previously, failed with:

```
Comment: Unable to manage file: Jinja error: 'NoneType' object is not iterable
              Traceback (most recent call last):
                File "/usr/lib/pymodules/python2.7/salt/utils/templates.py", line 263, in render_jinja_tmpl
                  output = jinja_env.from_string(tmplstr).render(**unicode_context)
                File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 894, in render
                  return self.environment.handle_exception(exc_info, True)
                File "<template>", line 7, in top-level template code
                File "/usr/lib/python2.7/dist-packages/jinja2/filters.py", line 698, in do_list
                  return list(value)
              TypeError: 'NoneType' object is not iterable

              ; line 7

              ---
              [...]
              {
                "client": {
                  "name": "{{grains['fqdn']}}",
                  "address": "{{grains['fqdn_ip4']}}",
                  "metric_prefix": "{{ grains['fqdn'].split('.')|reverse| join('.') }}",
                  "subscriptions": {{(roles|list + ['all']|list) |json}}    <======================
                }
              }
```
