### PR TITLE
Updating mixlib-shellout gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       test-kitchen (~> 1.0)
     mime-types (2.4.3)
     mini_portile (0.6.1)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     multi_json (1.10.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)


### PR DESCRIPTION
Pinned version (1.6.0) of `mixlib-shellout` gem which we were using was removed from public rubygems when the latest update was published so we had to update `Gemfile.lock`. We can only hope this won't happen again :-)
