### PR TITLE
Added 'mailer' handler, for sending formatted email alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
-* remove supervisor dependency
+* Remove supervisor dependency
+* Add ability to use the mailer handler from the community notification plugins.
 
 ## Version 4.4.3
 

--- a/README.rst
+++ b/README.rst
@@ -287,11 +287,34 @@ enable them in the pillar. You can enable as many as you like of the additional 
 Email
 -----
 
+Basic email notification.
+
 Example::
 
     sensu:
       notify:
         email: 'alerts@mydomain.com'
+
+
+Mailer
+------
+
+Advanced email notification. Provides more insight into the issue then basic email notification.
+
+The mailer handler handler sends formatted emails via the configured SMTP server.  With the default settings
+a local MTA is required.
+
+Example::
+
+    sensu:
+      notify:
+        mailer_mail_to: 'user@host.com'
+        mailer_mail_from: 'sensu@sensu.local'
+        mailer_smtp_address: 'localhost'
+        mailer_smtp_port: '25'
+        mailer_smtp_domain: 'sensu.local'
+        mailer_admin_gui: 'http://sensu.local'
+
 
 HipChat
 -------
@@ -321,23 +344,6 @@ Example::
     sensu:
       notify:
         pagerduty_apikey: 9e880a23f5ab1103bb7279896804e8a0
-
-Mailer
-------
-
-The mailer handler handler sends formatted emails via the configured SMTP server.  With the default settings
-a local MTA is required.
-
-Example::
-
-    sensu:
-      notify:
-        mailer_mail_to: 'user@host.com'
-        mailer_mail_from: 'sensu@sensu.local'
-        mailer_smtp_address: 'localhost'
-        mailer_smtp_port: '25'
-        mailer_smtp_domain: 'sensu.local'
-        mailer_admin_gui: 'http://sensu.local'
 
 
 apparmor

--- a/README.rst
+++ b/README.rst
@@ -322,6 +322,23 @@ Example::
       notify:
         pagerduty_apikey: 9e880a23f5ab1103bb7279896804e8a0
 
+Mailer
+------
+
+The mailer handler handler sends formatted emails via the configured SMTP server.  With the default settings
+a local MTA is required.
+
+Example::
+
+    sensu:
+      notify:
+        mailer_mail_to: 'user@host.com'
+        mailer_mail_from: 'sensu@sensu.local'
+        mailer_smtp_address: 'localhost'
+        mailer_smtp_port: '25'
+        mailer_smtp_domain: 'sensu.local'
+        mailer_admin_gui: 'http://sensu.local'
+
 
 apparmor
 ========

--- a/sensu/map.jinja
+++ b/sensu/map.jinja
@@ -26,7 +26,13 @@
             'hipchat_apikey': False,
             'hipchat_roomname': 'Alerts',
             'hipchat_from': False,
-            'hipchat_apiversion': 'v1'
+            'hipchat_apiversion': 'v1',
+            'mailer_mail_to': False,
+            'mailer_mail_from': False,
+            'mailer_smtp_address': 'localhost',
+            'mailer_smtp_port': '25',
+            'mailer_smtp_domain': False,
+            'mailer_admin_gui': 'http://sensu.local'
         },
         'community_plugins_rev': '474e375c3f',
         'check_definitions': {},
@@ -97,7 +103,13 @@
             'hipchat_apikey': False,
             'hipchat_roomname': 'Alerts',
             'hipchat_from': False,
-            'hipchat_apiversion': 'v1'
+            'hipchat_apiversion': 'v1',
+            'mailer_mail_to': False,
+            'mailer_mail_from': False,
+            'mailer_smtp_address': 'localhost',
+            'mailer_smtp_port': '25',
+            'mailer_smtp_domain': False,
+            'mailer_admin_gui': 'http://sensu.local'
         },
         'community_plugins_rev': '474e375c3f',
         'check_definitions': {},
@@ -165,7 +177,13 @@
             'hipchat_apikey': False,
             'hipchat_roomname': 'Alerts',
             'hipchat_from': False,
-            'hipchat_apiversion': 'v1'
+            'hipchat_apiversion': 'v1',
+            'mailer_mail_to': False,
+            'mailer_mail_from': False,
+            'mailer_smtp_address': 'localhost',
+            'mailer_smtp_port': '25',
+            'mailer_smtp_domain': False,
+            'mailer_admin_gui': 'http://sensu.local'
         },
         'community_plugins_rev': '474e375c3f',
         'check_definitions': {},

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -52,6 +52,17 @@ sensu_hipchat:
       - service: sensu-server
 {% endif %}
 
+{%- if sensu.notify.mailer_mail_to %}
+sensu_mailer:
+  cmd.run:
+    - name: /opt/sensu/embedded/bin/gem install mail
+    - unless: /opt/sensu/embedded/bin/gem list -i mail
+    - require:
+      - pkg: sensu
+    - watch_in:
+      - service: sensu-server
+{% endif %}
+
 /etc/sensu/conf.d/api.json:
   file.managed:
     - source: salt://sensu/templates/api.json

--- a/sensu/templates/handlers.json
+++ b/sensu/templates/handlers.json
@@ -31,6 +31,9 @@
 {%- if sensu.notify.email %}
         "email",
 {%- endif %}
+{%- if sensu.notify.mailer_mail_to %}
+        "mailer",
+{%- endif %}
         "stdout"
       ]
     },
@@ -54,6 +57,12 @@
     "email": {
       "type": "pipe",
       "command": "mail -s '[sensu] alert' {{sensu.notify.email}}"
+    },
+{%- endif %}
+{%- if sensu.notify.mailer_mail_to %}
+    "mailer": {
+      "type": "pipe",
+      "command": "/etc/sensu/community/handlers/notification/mailer.rb"
     },
 {%- endif %}
     "stdout": {


### PR DESCRIPTION
Added 'mailer' handler support from the community plugins for sending formatted emails.