### PR TITLE
Fix handlers.json syntax error.

### DIFF
--- a/sensu/templates/handlers.json
+++ b/sensu/templates/handlers.json
@@ -19,7 +19,7 @@
 {%- if sensu.notify["level-2-support_url"] %}
   "level-2-support": {
     "url": "{{ sensu.notify["level-2-support_url"] }}"
-  }
+  },
 {%- endif %}
 
   


### PR DESCRIPTION
Missing comma in handler config for second line support handler