### PR TITLE
Default handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Version 4.x.x
+## Version 5.0.0
 
+* Remove pagerduty from default handlers
 * Upgrade Uchiwa to 0.7.0-1
 * Move all checks to map.jinja, this makes them configurable from the pillar.
 

--- a/README.rst
+++ b/README.rst
@@ -354,6 +354,16 @@ Example::
       notify:
         pagerduty_apikey: 9e880a23f5ab1103bb7279896804e8a0
 
+You must also activate this handler for each check.
+
+Example::
+
+    sensu:
+      check_definitions:
+        used-root-disk:
+          handlers:
+            - pagerduty
+
 Grafana Integration
 -------------------
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+Pagerduty handler is no longer in the default set. If you upgrade to this version and need your checks to go to pagerduty you should put the following for each check in your pillar:
+
+```
+sensu:
+  check_definitions:
+    used-root-disk:
+      handlers:
+        - level-2-support
+```
+
 ## Version 3.x to 4.x
 
 This takes you from sensu 0.12.x to 0.13.x which has API breaking changes. This requires a new dashboard and a flush of the redis database. Ensure that your redis database with index 1 is only used by sensu, then:

--- a/sensu/templates/handlers.json
+++ b/sensu/templates/handlers.json
@@ -14,8 +14,6 @@
     "apikey": "{{ sensu.notify.hipchat_apikey }}"
   },
 {%- endif %}
-
-
 {%- if sensu.notify["level-2-support_url"] %}
   "level-2-support": {
     "url": "{{ sensu.notify["level-2-support_url"] }}"
@@ -36,9 +34,6 @@
       "handlers": [
 {%- if sensu.notify.hipchat_apikey %}
         "hipchat",
-{%- endif %}
-{%- if sensu.notify.pagerduty_apikey %}
-        "pagerduty",
 {%- endif %}
 {%- if sensu.notify.email %}
         "email",


### PR DESCRIPTION
This change removes pagerduty from the default handlers so that you have to explicitly add it to the handlers list on a check by check basis.

We're making this change to keep our phones quiet in general and only add alerts to pagerduty on checks that we really care about.