### PR TITLE
Fix missing pillar variable around level-2-support dashboard

### DIFF
--- a/sensu/map.jinja
+++ b/sensu/map.jinja
@@ -57,7 +57,8 @@
             'mailer_smtp_address': 'localhost',
             'mailer_smtp_port': '25',
             'mailer_smtp_domain': False,
-            'mailer_admin_gui': 'http://sensu.local'
+            'mailer_admin_gui': 'http://sensu.local',
+            'level-2-support_url': False,
         },
         'community_plugins_rev': '474e375c3f',
         'check_definitions': {


### PR DESCRIPTION
Without this we got a jinja error when trying to run a highstate without
sensu:notify:level-2-support set