### PR TITLE
(WIP) Add count/threshold alerts to the Elasticsarch check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 5.x.0
+
+* Extend check_elastic.rb to run count/threshold based checks too.
+
 ## Version 5.0.1
 
 * Fix syntax error in handlers.json

--- a/sensu/files/plugins/check-elastic.rb
+++ b/sensu/files/plugins/check-elastic.rb
@@ -25,34 +25,70 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
           :default => 'tags: rails'
   option  :out_string, :short => '-s out_string', :long => '--out-string out_string'
 
+  option  :warning,
+          :description => 'Generate warning if the number of matching records is >= VALUE and < :critical',
+          :short => '-w VALUE',
+          :long => '--warn VALUE',
+          :proc => proc { |arg| arg.to_i }
+
+  option  :critical,
+          :description => 'Generate critical if the number of matching records is >= VALUE',
+          :short => '-c VALUE',
+          :long => '--critical VALUE',
+          :proc => proc { |arg| arg.to_i }
+
   DEFAULT_SIZE=1
+
+  def _query_resource(resource, query, range)
+    query_data = {
+      'query' => {
+        'filtered' => {
+          'query' => {
+            'bool' => {
+              'should' => [
+                {
+                  'query_string' =>  {
+                    'query' => query
+                  }
+                }
+              ]
+            }
+          },
+          'filter' => {
+            'bool' => {
+              'must' => [
+                {
+                  'range'=> {
+                    '@timestamp' => {
+                      'gt' => "now-#{range}"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+
+    url = "#{config[:es_proto]}://#{config[:es_host]}:#{config[:es_port]}/#{resource}"
+    r = RestClient.post url, JSON.generate(query_data),
+                {:content_type => :json, :accept => :json}
+    JSON.parse(r)
+  end
 
   def get_data(size=DEFAULT_SIZE)
     today = Time.now.strftime('%Y.%m.%d')
     resource = "logstash-#{today}/_search?pretty&size=#{size}"
-    query_data = {'query' => {
-                    'filtered' => {
-                      'query' => {
-                        'query_string' =>  {
-                          'query' => "#{config[:query]}"
-                        }
-                      }
-                    }
-                  }, 'filter' => {
-                      'range'=> {
-                        '@timestamp' => {
-                          'gt' => "now-#{config[:range]}"
-                        }
-                      }
-                    }
-                }
-              
-    url = "#{config[:es_proto]}://#{config[:es_host]}:#{config[:es_port]}/#{resource}"
-    # RestClient.log = 'stdout'
-    r = RestClient.post url, JSON.generate(query_data), 
-                {:content_type => :json, :accept => :json}
-    JSON.parse(r)
+    _query_resource(resource, config[:query], config[:range])
   end
+
+  def get_count()
+    today = Time.now.strftime('%Y.%m.%d')
+    resource = "logstash-#{today}/_count?pretty"
+    _query_resource(resource, config[:query], config[:range])
+  end
+
 
   def submit_alert(alert_string)
     s = TCPSocket.open('localhost', 3030)
@@ -71,10 +107,43 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
   end
 
   def run
+    if config[:critical] != nil || config[:warning] != nil
+      run_threshold_check
+    else
+      run_result_check
+    end
+  end
+
+  # This will raise an alert (that closes itself) when the thresholds are back
+  # below the limit.
+  def run_threshold_check
+    data = get_count
+    count = data['count']
+
+    if config[:out_string]
+      out = config[:out_string]
+    else
+      out = "#{config[:check]} #{count} records matched"
+    end
+
+    if config[:critical] != nil && count >= config[:critical]
+      critical "#{out} is above the CRITICAL limit: #{count} count / #{config[:critical]} limit"
+    elsif config[:warning] != nil && count >= config[:warning]
+      warning "#{out} is above the WARNING limit: #{count} count / #{config[:warning]} limit"
+    else
+      ok out
+    end
+  end
+
+  # This will submit a check that will not every close itself. This was
+  # designed for apparmor violoation checks which run every 5 minutes and
+  # just because there were no alerts in the next 5 minutes doesn't mean the
+  # problem is solved.
+  def run_result_check
     data = get_data
     hits =  data['hits']['total']
     err = 0
-    success = 0    
+    success = 0
     if hits > 0
       if hits > DEFAULT_SIZE
         data = get_data(hits)

--- a/sensu/lib.sls
+++ b/sensu/lib.sls
@@ -40,7 +40,8 @@ execute check is process exists
     - group: sensu
     - context:
         name: {{name}}
-        command: {{command}}
+        # {# TODO: When we upgrade to a more recent salt change this to {{command|yaml_encode}} #}
+        command: "{{command}}"
         handlers: {{handlers}}
         interval: {{interval}}
         standalone: {{standalone}}


### PR DESCRIPTION
We wanted an alert for PVB that was 'number of 500 log entries in the last
hour, and this check script was most of the way there already.

If we want we can put `self.class.check_name(config[:tag])` into the
`#run_threshold_check` and it changes the output from:

> ElasticSearchCheck OK: Number of 5XX responses over last hour

to

> App500Errors OK: Number of 5XX responses over last hour

Is this worth doing? Is it too hacky?