### PR TITLE
Allow ElasticSearch check to override the name it reports itself as

### DIFF
--- a/sensu/files/plugins/check-elastic.rb
+++ b/sensu/files/plugins/check-elastic.rb
@@ -33,8 +33,6 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
   option  :handler, :short => '-l handler', :long => '--handler handler',
           :default => 'default',
           :description => 'Handler to raise alerts on a per host basis for any results found'
-  option  :result_key, :short => '-k result_key', :long => '--result-key result_key',
-          :default => 'message'
   option  :tag, :short => '-t tagname', :long => '--tag tagname',
           :default => 'apparmor',
           :description => 'Name prefix for alerts created. Will create events with this form "#{tag}_#{host}"'
@@ -174,7 +172,6 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
       end
       for result in data['hits']['hits']
         hostname = result['_source']['host']
-        details = result['_source'][config[:result_key]]
         if config[:out_string]
           out = config[:out_string]
         else

--- a/sensu/files/plugins/check-elastic.rb
+++ b/sensu/files/plugins/check-elastic.rb
@@ -33,9 +33,8 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
   option  :handler, :short => '-l handler', :long => '--handler handler',
           :default => 'default',
           :description => 'Handler to raise alerts on a per host basis for any results found'
-  option  :tag, :short => '-t tagname', :long => '--tag tagname',
-          :default => 'apparmor',
-          :description => 'Name prefix for alerts created. Will create events with this form "#{tag}_#{host}"'
+  option  :prefix, :long => '--nameprefix prefix',
+          :description => 'Name prefix for all non-threshold alerts created. Will create events with this form "#{prefix}_#{host}"'
 
   # These options apply only to run_threshold_check
   option  :name,
@@ -177,7 +176,7 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
         else
           out = "Check host for ES query string: #{config[:query]}"
         end
-        msg = JSON.generate({ 'name' => "#{config[:tag]}_#{hostname}",
+        msg = JSON.generate({ 'name' => "#{config[:prefix]}_#{hostname}",
           'status' => 2, 'output' => out,
           'handler' => config[:handler] })
         res = submit_alert(msg)

--- a/sensu/files/plugins/check-elastic.rb
+++ b/sensu/files/plugins/check-elastic.rb
@@ -7,24 +7,39 @@ require 'sensu-plugin/check/cli'
 require 'socket'
 
 class ElasticSearchCheck < Sensu::Plugin::Check::CLI
+
+  # These options apply to both check styles
   option  :es_proto, :short => '-o HTTP(S)', :long => '--es-proto HTTP(S)',
           :default => 'http'
   option  :es_host, :short => '-h ES_HOST', :long => '--es-host ES_HOST', 
           :default => 'localhost'
   option  :es_port, :short => '-p ES_PORT', :long => '--es-port ES_PORT',
           :default => '9200'
-  option  :tag, :short => '-t tagname', :long => '--tag tagname',
-          :default => 'apparmor'
+
   option  :range, :short => '-r range', :long => '--range range',
-          :default => '10m'
+          :default => '10m',
+          :description => 'Time range to ask Elasticsearch to return results for.'
+
+  option  :query, :short => '-q query', :long => '--query query',
+          :default => 'tags: rails',
+          :description => 'The query_string part of the Elasticsearch query (i.e. not the full JSON, just a simple string)'
+
+  option  :out_string,
+          :short => '-s out_string',
+          :long => '--out-string out_string',
+          :description => 'Message to send along with the check'
+
+  # These optons apply only to the non-threshold based alert, see run_result_check
   option  :handler, :short => '-l handler', :long => '--handler handler',
-          :default => 'default'
+          :default => 'default',
+          :description => 'Handler to raise alerts on a per host basis for any results found'
   option  :result_key, :short => '-k result_key', :long => '--result-key result_key',
           :default => 'message'
-  option  :query, :short => '-q query', :long => '--query query',
-          :default => 'tags: rails'
-  option  :out_string, :short => '-s out_string', :long => '--out-string out_string'
+  option  :tag, :short => '-t tagname', :long => '--tag tagname',
+          :default => 'apparmor',
+          :description => 'Name prefix for alerts created. Will create events with this form "#{tag}_#{host}"'
 
+  # These options apply only to run_threshold_check
   option  :name,
           :long => '--name checkname',
           :description => 'Override the name of this check from default of ElasticSearchCheck'

--- a/sensu/files/plugins/check-elastic.rb
+++ b/sensu/files/plugins/check-elastic.rb
@@ -25,6 +25,10 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
           :default => 'tags: rails'
   option  :out_string, :short => '-s out_string', :long => '--out-string out_string'
 
+  option  :name,
+          :long => '--name checkname',
+          :description => 'Override the name of this check from default of ElasticSearchCheck'
+
   option  :warning,
           :description => 'Generate warning if the number of matching records is >= VALUE and < :critical',
           :short => '-w VALUE',
@@ -119,6 +123,11 @@ class ElasticSearchCheck < Sensu::Plugin::Check::CLI
   def run_threshold_check
     data = get_count
     count = data['count']
+
+    # Override the check name to be more specific as requested
+    if config[:name]
+      self.class.check_name(config[:name])
+    end
 
     if config[:out_string]
       out = config[:out_string]

--- a/sensu/map.jinja
+++ b/sensu/map.jinja
@@ -71,7 +71,7 @@
             },
             'apparmor_check': {
                 'type': 'basic',
-                'command': "/etc/sensu/plugins/check-elastic.rb -r 5m -q 'tags:apparmor NOT apparmor_evt:STATUS' -t apparmor  -s 'AppArmor violation! Please check the logs'",
+                'command': "/etc/sensu/plugins/check-elastic.rb -r 5m -q 'tags:apparmor NOT apparmor_evt:STATUS' --nameprefix ApparmorViolation -s 'AppArmor violation! Please check the logs'",
                 'handlers': ['hipchat'],
                 'interval': 300,
                 'playbook': 'https://github.com/ministryofjustice/sensu-formula/tree/master/docs/playbooks/apparmor.md'

--- a/sensu/map.jinja
+++ b/sensu/map.jinja
@@ -71,7 +71,7 @@
             },
             'apparmor_check': {
                 'type': 'basic',
-                'command': "/etc/sensu/plugins/check-elastic.rb -r 5m -k 'apparmor_rest' -q 'tags:apparmor NOT apparmor_evt:STATUS' -t apparmor  -s 'AppArmor violation! Please check the logs'",
+                'command': "/etc/sensu/plugins/check-elastic.rb -r 5m -q 'tags:apparmor NOT apparmor_evt:STATUS' -t apparmor  -s 'AppArmor violation! Please check the logs'",
                 'handlers': ['hipchat'],
                 'interval': 300,
                 'playbook': 'https://github.com/ministryofjustice/sensu-formula/tree/master/docs/playbooks/apparmor.md'


### PR DESCRIPTION
This means that instead of seeing:

> ElasticSearchCheck OK: Number of 5XX responses over last hour

we can change it to be:

> App500Errors OK: Number of 5XX responses over last hour

It's a small change but it makes it a lot easier to see what the problem
is, espeically when the alert is going via PagerDuty

(This was discussed in #70)