### PR TITLE
Restart sensu-server when checks are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Version 5.1.x
 
+* Restart sensu-server when checks are removed as well as added
+
+## Version 5.1.1
+
 * Add a collectd script to graph redis process information (memory, cpu, etc)
 
 ## Version 5.1.0

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -96,6 +96,7 @@ sensu-server:
       - file: /etc/sensu/conf.d/rabbitmq.json
       - file: /etc/sensu/conf.d/handlers.json
       - file: /etc/sensu/conf.d/checks/*
+      - file: sensu-confd-checks-clean
 
 /etc/apparmor.d/opt.sensu.embedded.bin.sensu-server:
   file.managed:


### PR DESCRIPTION
Sensu doesn't notice when checks are removed unless we restart, and we're currently only watching for additions; this fixes that problem by watching the check-clean state.