### PR TITLE
Restart sensu-api when checks change

### DIFF
--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -112,6 +112,8 @@ sensu-api:
       - file: /etc/default/sensu
       - file: /etc/sensu/conf.d/api.json
       - file: /etc/sensu/conf.d/redis.json
+      - file: /etc/sensu/conf.d/checks/*
+      - file: sensu-confd-checks-clean
 
 /etc/apparmor.d/opt.sensu.embedded.bin.sensu-api:
   file.managed:


### PR DESCRIPTION
It would appear that `sensu-api` needs to be restarted in addition to `sensu-server` when checks are deleted, or they won't disappear from the UI.
