### PR TITLE
Allow `ps` and `sh` commands to pass AppArmour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 5.1.4
+
+* Add `ps` and `sh` to sensu-client apparmor profile to silence normal
+  behavior
+
 ## Version 5.1.3
 
 * Restart sensu-api as well as sensu-server when checks change
@@ -171,7 +176,7 @@
   ruby when pagerduty/hipchat integration is enabled
 * Changed the Hipchat API to v1 to avoid the API key being associated
   with a person
-* Removed additional subscriptions based on roles. This is not used at 
+* Removed additional subscriptions based on roles. This is not used at
   present and causes a failure on machines where roles are not defined
 
 ## Version 2.1.1
@@ -181,7 +186,7 @@
 ## Version 2.1.0
 
 * Added support for email, hipchat and pagerduty notification (see README)
-* Moved notification pillar values to sensu.notify.* 
+* Moved notification pillar values to sensu.notify.*
 * Tidied up require/watch logic on server/client setup
 
 ## Version 2.0.0

--- a/sensu/templates/api_apparmor_profile
+++ b/sensu/templates/api_apparmor_profile
@@ -5,6 +5,8 @@
   #include <abstractions/base>
   #include <abstractions/ruby>
 
+  /bin/ps ix,
+  /bin/sh ix,
   /etc/sensu/** r,
   /opt/sensu/embedded/bin/ruby ix,
   /opt/sensu/embedded/bin/sensu-api r,


### PR DESCRIPTION
Allowing `ps` and `sh` calls should eliminate 80% of the AppArmor false alerts we are currently receiving on PVB.