### PR TITLE
Fix dead link to salts formulas guide in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,12 @@ Install and configure sensu and some simple common checks (disk, memory etc.)
 .. note::
 
     See the full `Salt Formulas installation and usage instructions
-    <http://docs.saltstack.com/topics/conventions/formulas.html>`_.
+    <http://docs.saltstack.com/topics/development/conventions/formulas.html>`_.
 
 Dependencies
 ============
 
-Playbooks for checks are available in `docs/playbooks https://github.com/ministryofjustice/sensu-formula/tree/master/docs/playbooks/>`_
+Playbooks for checks are available in `docs/playbooks <https://github.com/ministryofjustice/sensu-formula/tree/master/docs/playbooks/>`_.
 
 Dependencies
 ============


### PR DESCRIPTION
* (Closes #76) README's 'Salt Formulas installation and usage instructions.'
goes to, http://docs.saltstack.com/topics/conventions/formulas.html
which is dead. Sending it instead to
http://docs.saltstack.com/topics/development/conventions/formulas.html

* Fixed typo in docs/playbooks link causes causes the link to be shown