### PR TITLE
fixed sensu handlers template for multiple chat rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 5.2.x
+
+* Fix sensu handlers.json template to allow multiple hipchat rooms using the 
+  correct json syntax
+
 ## Version 5.2.0
 
 * Increased default ntp offset alert threshold from 10 to 20 mins, to reduce

--- a/sensu/templates/handlers.json
+++ b/sensu/templates/handlers.json
@@ -3,7 +3,11 @@
 
 {%- if sensu.notify.hipchat_apikey %}
   "hipchat": {
+{%- if sensu.notify.hipchat_roomname is string %}
     "room": "{{ sensu.notify.hipchat_roomname }}",
+{%- else %}
+    "room": {{ sensu.notify.hipchat_roomname | json }},
+{%- endif %}
 {%-   if sensu.notify.hipchat_from %}
     "from": "{{ sensu.notify.hipchat_from }}",
 {%-   endif %}


### PR DESCRIPTION
The sensu template for handlers could only deal with a string value for the hipchat chatroom.

This change allows to specify a list of chatrooms instead of a single one.
The change has been tested on PVB preprod running salt.
