### PR TITLE
Remedial work for hipchat sensu handler and NTP threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 5.2.2
+# Version 5.2.x
 
 * Fixed bug in the URL assembly for hipchat messages. 
   The Graph link in the hipchat message was broken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 5.2.2
+
+* Fixed bug in the URL assembly for hipchat messages. 
+  The Graph link in the hipchat message was broken.
+
+* Increased alert threshold for NTP offset empty datasets 
+  from 20 mins to 6hr, after getting spurious noisy 
+  intermittent alerts on PVB.
+
 ## Version 5.2.1
 
 * Fix sensu handlers.json template to allow multiple hipchat rooms using the 

--- a/sensu/files/handlers/hipchat.rb
+++ b/sensu/files/handlers/hipchat.rb
@@ -45,7 +45,7 @@ class HipChatNotif < Sensu::Handler
       unless metric_name.empty?
         full_target = metric_name.sub(':::metric_prefix:::', metric_prefix)
         uri = URI.parse(grafana_base + "targets=" + URI.encode(full_target).gsub(',', '%2C'))
-        message << "  [<a href='#{uri.to_s}'>Graph</a>]"
+        message << "  [<a href=\"#{uri.to_s}\">Graph</a>]"
       end
     end
 

--- a/sensu/map.jinja
+++ b/sensu/map.jinja
@@ -106,7 +106,7 @@
             'ntp-offset': {
                 'type': 'graphite',
                 'target': "alias(absolute(averageSeries(metrics.:::metric_prefix:::.ntpd.time_offset.*.*.*.*)),'NTP-offset')",
-                'params': '-a 1200',
+                'params': '-a 21600',
                 'description': 'NTP offset',
                 'occurrences': '2',
                 'playbook': 'https://github.com/ministryofjustice/sensu-formula/tree/master/docs/playbooks/ntp-offset.md'


### PR DESCRIPTION
* Fixed bug in the URL assembly for hipchat messages. 
  The Graph link in the hipchat message was broken.

* Increased alert threshold for NTP offset empty datasets 
  from 20 mins to 6hr, after getting spurious noisy 
  intermittent alerts on PVB.

* updated CHANGELOG.md in preparation for new release