### PR TITLE
Add a pretty option to the graphite plugin for simpler messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Add a --pretty option to the graphite plugin for simpler messages
+
 ## Version 5.2.x
 
 * Fixed bug in the URL assembly for hipchat messages. 


### PR DESCRIPTION
Graphite check alert output is quite verbose. This will add a --pretty
option to the graphite plugin, which makes the plugin try to produce
a simpler and more clear output (Closes #16)

For example
* A simpler message
* Percents to 2 decimal places rather than 8+
* Percent signs for percent units

The complex raw message is similar to
ALERT - [front-01.staging1.pvb/graphite-used-root-disk]
- CheckGraphiteData CRITICAL: Root Disk Used Percentage (93.539437488085)
[asPercent(metrics.pvb.staging1.front-01.df.root.df_complex.used,
sumSeries(metrics.pvb.staging1.front-01.df.root.df_complex.{free,used}))]

When the --pretty option is passed this becomes
CheckGraphiteData CRITICAL: Root Disk Used Percentage is above critical limit: 98.5% / 95.0%