### PR TITLE
enable ptrace only if we're on something later than ubuntu 14.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 * Add a --pretty option to the graphite plugin for simpler messages
+* Check the ubuntu version before enabling ptrace for apparmor
 
 ## Version 5.2.x
 

--- a/sensu/templates/client_apparmor_profile
+++ b/sensu/templates/client_apparmor_profile
@@ -47,8 +47,8 @@
   /usr/local/lib/ruby/2.0.0/** mr,
   /usr/local/lib/ruby/gems/2.0.0/** r,
   /var/log/sensu/* w,
-{% set kerver = salt['grains.get']('kernelrelease').split('.') %}
-{% if kerver[0]|int >= 4 or ( kerver[0]|int == 3 and kerver[1]|int >= 13 ) %}
+{% set distrib = salt['grains.get']('lsb_distrib_release').split('.') %}
+{% if distrib[0]|int >= 14 %}
 
   ptrace (read),
   ptrace (trace),


### PR DESCRIPTION
Instead of checking the kernel version we should check the ubuntu version, as it's not only the kernel that matters but the version of apparmor too.