### PR TITLE
Fix `occurrences` for sensu_check_graphite not ending up in the file on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 5.2.x
+
+* Fix `occurrences` for sensu_check_graphite not ending up in the file on disk
+
 ## Version 5.2.3
 
 * Add a --pretty option to the graphite plugin for simpler messages

--- a/sensu/lib.sls
+++ b/sensu/lib.sls
@@ -82,5 +82,5 @@ execute check is process exists
   {% set params = params + " -c " ~ p_data.critical %}
 {% endif %}
 {% set check_cmd = "/etc/sensu/plugins/graphite-data.rb -s " + sensu.graphite.host + ":" ~ sensu.graphite.port ~ " -t '"+metric_name+"' -n '"+desc+"' " + params %}
-{{ sensu_check(name="graphite-"+name, command=check_cmd, metric_name=metric_name, **kwargs) }}
+{{ sensu_check(name="graphite-"+name, command=check_cmd, metric_name=metric_name, occurrences=occurrences, **kwargs) }}
 {% endmacro %}


### PR DESCRIPTION
Beacuase we had pulled `occurrences` in the macro as an explict named
arg it wasn't in kwargs, so we need to explictly pass it down the the
base sensu_check macro